### PR TITLE
also cleanup if run from another folder

### DIFF
--- a/forward-merge.sh
+++ b/forward-merge.sh
@@ -18,7 +18,7 @@
 # under the License.
 
 # Clean up
-tmpMessageFile=".git-tmp-message.txt"
+tmpMessageFile="${PWD}/.git-tmp-message.txt"
 rm -f ${tmpMessageFile}
 
 # Stop executing when we encounter errors

--- a/merge-pr.sh
+++ b/merge-pr.sh
@@ -18,9 +18,9 @@
 # under the License.
 
 # Vars we need
-tmpMessageFile=".git-tmp-message.txt"
-tmpGemfile="Gemfile"
-tmpVendorDir="vendor"
+tmpMessageFile="${PWD}/.git-tmp-message.txt"
+tmpGemfile="${PWD}/Gemfile"
+tmpVendorDir="${PWD}/vendor"
 
 # Clean up
 rm -fr ${tmpMessageFile} ${tmpGemfile} ${tmpGemfile}.lock .bundle


### PR DESCRIPTION
When I call the scripts with a path, it creates the tmp files in my current working dir (the cloudstack repo). They are now also cleaned.
